### PR TITLE
fix: improve UI readability and styling

### DIFF
--- a/screens/SettingsScreen.tsx
+++ b/screens/SettingsScreen.tsx
@@ -93,7 +93,7 @@ export const SettingsScreen: React.FC = () => {
       }
     } catch (error) {
       console.error('Update check failed:', error);
-      Alert.alert('Error', 'Failed to check for updates: ' + error.message);
+      Alert.alert('Error', 'Failed to check for updates: ' + (error instanceof Error ? error.message : String(error)));
     }
   };
 
@@ -196,7 +196,7 @@ export const SettingsScreen: React.FC = () => {
               Copyright 2025 by Erik Wagner
             </Text>
             <Text style={[FONTS.caption, styles.debugText]}>
-              Channel: {getUpdateDebugInfo().channel} | Update: {getUpdateDebugInfo().updateId}
+              {getUpdateDebugInfo().channel} • {getUpdateDebugInfo().updateId}
             </Text>
           </View>
         </View>
@@ -299,11 +299,27 @@ const styles = StyleSheet.create({
   },
   footer: {
     paddingVertical: SPACING.lg,
+    paddingHorizontal: SPACING.md,
     alignItems: 'center',
+    minHeight: 80, // Ensure minimum height for proper spacing
+  },
+  versionText: {
+    color: COLORS.textSecondary,
+    textAlign: 'center',
+    marginBottom: SPACING.sm, // Increased spacing
+    fontSize: 14,
   },
   copyrightText: {
     color: COLORS.textSecondary,
     textAlign: 'center',
+    marginBottom: SPACING.sm, // Added spacing
+    fontSize: 12,
+  },
+  debugText: {
+    color: COLORS.textSecondary,
+    textAlign: 'center',
+    fontSize: 10, // Smaller font for debug info
+    opacity: 0.7, // Make it less prominent
   },
   switchContainer: {
     flexDirection: 'row',
@@ -316,11 +332,6 @@ const styles = StyleSheet.create({
     color: COLORS.text,
     flex: 1,
   },
-  versionText: {
-    color: COLORS.textSecondary,
-    textAlign: 'center',
-    marginBottom: SPACING.xs,
-  },
   updateButton: {
     backgroundColor: COLORS.primary,
     paddingHorizontal: SPACING.md,
@@ -332,10 +343,5 @@ const styles = StyleSheet.create({
   updateButtonText: {
     color: COLORS.background,
     fontWeight: '600',
-  },
-  debugText: {
-    color: COLORS.textSecondary,
-    textAlign: 'center',
-    marginTop: SPACING.xs,
   },
 }); 

--- a/screens/StartupScreen.tsx
+++ b/screens/StartupScreen.tsx
@@ -32,9 +32,14 @@ export const StartupScreen: React.FC = () => {
         <View style={styles.mainContent}>
           {/* App Title */}
           <View style={styles.titleSection}>
-            <Text style={[FONTS.h1, styles.title]}>
-              2468 Scorekeeper
-            </Text>
+            <View style={styles.titleContainer}>
+              <Text style={[FONTS.h1, styles.title]}>
+                2468{' '}
+              </Text>
+              <Text style={[FONTS.h1, styles.scorekeeperTitle]}>
+                Scorekeeper
+              </Text>
+            </View>
             <Text style={[FONTS.body, styles.subtitle]}>
               Keep track of your 2468 games!
             </Text>
@@ -199,5 +204,17 @@ const styles = StyleSheet.create({
   },
   settingsIcon: {
     fontSize: 24,
+  },
+  titleContainer: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+  },
+  scorekeeperTitle: {
+    color: COLORS.primary,
+    textAlign: 'center',
+    fontSize: 32,
+    fontWeight: 'bold',
   },
 }); 

--- a/temp_settings_fix.txt
+++ b/temp_settings_fix.txt
@@ -1,0 +1,12 @@
+          {/* Footer */}
+          <View style={styles.footer}>
+            <Text style={[FONTS.caption, styles.versionText]}>
+              Version {Constants.expoConfig?.version}
+            </Text>
+            <Text style={[FONTS.caption, styles.copyrightText]}>
+              Copyright 2025 by Erik Wagner
+            </Text>
+            <Text style={[FONTS.caption, styles.debugText]}>
+              {getUpdateDebugInfo().channel} • {getUpdateDebugInfo().updateId}
+            </Text>
+          </View>


### PR DESCRIPTION
- Split StartupScreen title into separate components with custom font sizes
- Make 'Scorekeeper' text 32px for better visual hierarchy
- Improve SettingsScreen footer spacing and readability in portrait mode
- Add proper margins and font sizes for version information
- Fix TypeScript error in error handling for update checks
- Make debug text more compact and less prominent